### PR TITLE
feat: add sslcheck command

### DIFF
--- a/cmd/sslcheck.go
+++ b/cmd/sslcheck.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"admin-cli/internal"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var sslHost string
+var sslPort int
+
+var sslCheckCmd = &cobra.Command{
+	Use:   "sslcheck",
+	Short: "Check SSL certificate expiration",
+	Run: func(cmd *cobra.Command, args []string) {
+		expiry, err := internal.CheckSSLExpiry(sslHost, sslPort)
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			return
+		}
+		daysRemaining := int(time.Until(expiry).Hours() / 24)
+		fmt.Printf("Certificate for %s:%d expires on: %s (%d days remaining)\n", sslHost, sslPort, expiry.Format("2006-01-02"), daysRemaining)
+	},
+}
+
+func init() {
+	sslCheckCmd.Flags().StringVar(&sslHost, "host", "", "Host to check")
+	sslCheckCmd.Flags().IntVar(&sslPort, "port", 443, "Port to check")
+	sslCheckCmd.MarkFlagRequired("host")
+	rootCmd.AddCommand(sslCheckCmd)
+}

--- a/internal/sslcheck.go
+++ b/internal/sslcheck.go
@@ -1,0 +1,22 @@
+package internal
+
+import (
+	"crypto/tls"
+	"fmt"
+	"time"
+)
+
+func CheckSSLExpiry(host string, port int) (time.Time, error) {
+	conn, err := tls.DialWithDialer(&tls.Dialer{Timeout: 5 * time.Second}, "tcp", fmt.Sprintf("%s:%d", host, port), nil)
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer conn.Close()
+
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return time.Time{}, fmt.Errorf("no certificates found")
+	}
+
+	return certs[0].NotAfter, nil
+}

--- a/internal/sslcheck.go
+++ b/internal/sslcheck.go
@@ -3,11 +3,13 @@ package internal
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
 	"time"
 )
 
 func CheckSSLExpiry(host string, port int) (time.Time, error) {
-	conn, err := tls.DialWithDialer(&tls.Dialer{Timeout: 5 * time.Second}, "tcp", fmt.Sprintf("%s:%d", host, port), nil)
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	conn, err := tls.DialWithDialer(dialer, "tcp", fmt.Sprintf("%s:%d", host, port), &tls.Config{})
 	if err != nil {
 		return time.Time{}, err
 	}


### PR DESCRIPTION
This PR adds a new `sslcheck` command to the `admin-cli` to check SSL certificate expiration. It was implemented and verified using the CIAO orchestration system.